### PR TITLE
BUGFIX: size was not re-calculated

### DIFF
--- a/pkg/replace_annotations.go
+++ b/pkg/replace_annotations.go
@@ -70,6 +70,10 @@ func (a imageAnnotationsReplacer) Digest() (v1.Hash, error) {
 	return partial.Digest(a)
 }
 
+func (a imageAnnotationsReplacer) Size() (int64, error) {
+	return partial.Size(a)
+}
+
 func (a imageAnnotationsReplacer) Manifest() (*v1.Manifest, error) {
 	return partial.Manifest(a)
 }
@@ -87,6 +91,10 @@ func (a indexAnnotationsReplacer) RawManifest() ([]byte, error) {
 
 func (a indexAnnotationsReplacer) Digest() (v1.Hash, error) {
 	return partial.Digest(a)
+}
+
+func (a indexAnnotationsReplacer) Size() (int64, error) {
+	return partial.Size(a)
 }
 
 func (a indexAnnotationsReplacer) Manifest() (*v1.Manifest, error) {


### PR DESCRIPTION
Did not cause any issues when testing with docker, but caused kubernetes to fail!

```
Failed to pull image "...": rpc error: code = FailedPrecondition desc = failed to pull and unpack image "...": failed commit on ref "manifest-sha256:50c9a7a9ad1c8e2985d75a830f213820360bbd792ef66afe498e21e6307680dc": "manifest-sha256:50c9a7a9ad1c8e2985d75a830f213820360bbd792ef66afe498e21e6307680dc" failed size validation: 1643 != 1200: failed precondition
```

The size of the modified manifest was not re-calculated, causing the reference to contain an incorrect size.
